### PR TITLE
Typo in src/documents/abbreviations/types/index.html.md

### DIFF
--- a/src/documents/abbreviations/types/index.html.md
+++ b/src/documents/abbreviations/types/index.html.md
@@ -79,7 +79,7 @@ In `snippets.json` file, you can find the following definitions:
 	...
 	"html": {
 		"abbreviatoins": {
-			"bq": "blockuote",
+			"bq": "blockquote",
 			"ol+": "ol>li"
 		}
 	}


### PR DESCRIPTION
In 'Aliases' section, "blockuote" -> "blockquote".
