### PR TITLE
Fixed typo

### DIFF
--- a/src/documents/abbreviations/types/index.html.md
+++ b/src/documents/abbreviations/types/index.html.md
@@ -78,7 +78,7 @@ In `snippets.json` file, you can find the following definitions:
 
 	...
 	"html": {
-		"abbreviatoins": {
+		"abbreviations": {
 			"bq": "blockquote",
 			"ol+": "ol>li"
 		}


### PR DESCRIPTION
"abbreviatoins" for "abbreviations".
