### PR TITLE
Make disqus secure

### DIFF
--- a/src/layouts/default.html.eco
+++ b/src/layouts/default.html.eco
@@ -95,7 +95,7 @@ js:  "/js/main.js"
 			var dsq = document.createElement('script');
 			dsq.type = 'text/javascript';
 			dsq.async = true;
-		    dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+		    dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 			document.getElementsByTagName('head')[0].appendChild(dsq);
 		})();
 	}


### PR DESCRIPTION
Prevent `Mixed Content: The page at 'https://docs.emmet.io/actions/expand-abbreviation/' was loaded over HTTPS, but requested an insecure script 'http://emmetdocs.disqus.com/embed.js'. This request has been blocked; the content must be served over HTTPS` error on Chrome