### PR TITLE
revision ".class"

### DIFF
--- a/js/cheatsheet/cheatsheet-controller.js
+++ b/js/cheatsheet/cheatsheet-controller.js
@@ -160,16 +160,16 @@ $(function() {
 			name: 'Implicit tag names',
 			value: [
 				{
-					name: '.class',
-					value: '<div class="class"></div>',
+					name: '.className',
+					value: '<div class="className"></div>',
 					type: 'snippet'
 				}, {
-					name: 'em>.class',
-					value: '<em><span class="class"></span></em>',
+					name: 'em>.className',
+					value: '<em><span class="className"></span></em>',
 					type: 'snippet'
 				}, {
-					name: 'ul>.class',
-					value: '<ul>\n\t<li class="class"></li>\n</ul>',
+					name: 'ul>.className',
+					value: '<ul>\n\t<li class="className"></li>\n</ul>',
 					type: 'snippet'
 				}, {
 					name: 'table>.row>.col',

--- a/js/cheatsheet/syntax-section.js
+++ b/js/cheatsheet/syntax-section.js
@@ -111,14 +111,14 @@ var syntaxSection = [
 		name: 'Implicit tag names',
 		value: [
 			{
-				name: '.class',
-				value: '<div class="class"></div>'
+				name: '.className',
+				value: '<div class="className"></div>'
 			}, {
-				name: 'em>.class',
-				value: '<em><span class="class"></span></em>'
+				name: 'em>.className',
+				value: '<em><span class="className"></span></em>'
 			}, {
-				name: 'ul>.class',
-				value: '<ul>\n\t<li class="class"></li>\n</ul>'
+				name: 'ul>.className',
+				value: '<ul>\n\t<li class="className"></li>\n</ul>'
 			}, {
 				name: 'table>.row>.col',
 				value: '<table>\n\t<tr class="row">\n\t\t<td class="col"></td>\n\t</tr>\n</table>'

--- a/src/files/old-js/cheatsheet-controller.js
+++ b/src/files/old-js/cheatsheet-controller.js
@@ -160,16 +160,16 @@ $(function() {
 			name: 'Implicit tag names',
 			value: [
 				{
-					name: '.class',
-					value: '<div class="class"></div>',
+					name: '.className',
+					value: '<div class="className"></div>',
 					type: 'snippet'
 				}, {
-					name: 'em>.class',
-					value: '<em><span class="class"></span></em>',
+					name: 'em>.className',
+					value: '<em><span class="className"></span></em>',
 					type: 'snippet'
 				}, {
-					name: 'ul>.class',
-					value: '<ul>\n\t<li class="class"></li>\n</ul>',
+					name: 'ul>.className',
+					value: '<ul>\n\t<li class="className"></li>\n</ul>',
 					type: 'snippet'
 				}, {
 					name: 'table>.row>.col',


### PR DESCRIPTION
cannot use the word `.class` in emmet as an example because it will not produce as expected, for example: If `.class` is used, the result will be `<div class></div>` not `<div class ="class"></div>`